### PR TITLE
VS 2026 support (code only; CI not yet implemented)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,16 +44,17 @@ set_target_properties(_iris_x4_cxx_common PROPERTIES CXX_EXTENSIONS OFF)
 # Create the main X4 target
 
 if(MSVC)
+    # This needs to be `OBJECT` target to set correct `/std:` flags on IDE
     add_library(iris_x4 OBJECT EXCLUDE_FROM_ALL)
+    set_target_properties(iris_x4 PROPERTIES LINKER_LANGUAGE CXX)
+
     target_sources(
         iris_x4
         PRIVATE
-            # required for determining correct `/std:` flag
-            "${PROJECT_SOURCE_DIR}/test/dummy.cpp"
-
             # "${PROJECT_SOURCE_DIR}/cpp.hint" # TODO
             # "${PROJECT_SOURCE_DIR}/iris_x4.natvis" # TODO
     )
+
 else()
     add_library(iris_x4 INTERFACE)
 endif()

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ X4 scales from quick prototypes to production parsers for DSLs, data formats, an
 - C++23 and C++26
 - GCC 14
 - Clang 21
-- MSVC 2022
+- MSVC 2022 and 2026
 
 ## How to use X4
 

--- a/include/iris/config.hpp
+++ b/include/iris/config.hpp
@@ -18,7 +18,7 @@
 #define IRIS_CONCAT(a, b) IRIS_CONCAT_I(a, b)
 
 #if _MSC_VER
-# include <CodeAnalysis/CppCoreCheck/warnings.h>
+# include <CppCoreCheck/warnings.h>
 # pragma warning(default: CPPCORECHECK_LIFETIME_WARNINGS)
 #endif
 

--- a/test/dummy.cpp
+++ b/test/dummy.cpp
@@ -1,7 +1,0 @@
-// Copyright 2025 Nana Sakisaka
-//
-// Distributed under the Boost Software License, Version 1.0.
-// https://www.boost.org/LICENSE_1_0.txt
-
-// Required for guiding CMake to correctly set the MSVC `/std:` flag on header-only library.
-


### PR DESCRIPTION
It turned out that VS 2026 almost works out of the box. This PR includes some minor tweaks that eliminates the need of `dummy.cpp` for setting `/std:` flags on header-only target.

Note: CI is not yet ready (soon to be supported on GHA). Will be handled on some follow-up PR once https://github.com/actions/runner-images/issues/13291 is ready.