### PR TITLE
Implement `without<IDs...>[p]` directive

### DIFF
--- a/include/iris/x4/directive.hpp
+++ b/include/iris/x4/directive.hpp
@@ -24,5 +24,6 @@
 #include <iris/x4/directive/skip.hpp>
 #include <iris/x4/directive/with.hpp>
 #include <iris/x4/directive/with_local.hpp>
+#include <iris/x4/directive/without.hpp>
 
 #endif

--- a/include/iris/x4/directive/without.hpp
+++ b/include/iris/x4/directive/without.hpp
@@ -1,0 +1,73 @@
+#ifndef IRIS_X4_DIRECTIVE_WITHOUT_HPP
+#define IRIS_X4_DIRECTIVE_WITHOUT_HPP
+
+/*=============================================================================
+    Copyright (c) 2026 The Iris Project Contributors
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <iris/x4/core/parser.hpp>
+#include <iris/x4/core/context.hpp>
+
+#include <format>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace iris::x4 {
+
+template<class Subject, class... IDs>
+struct without_directive : proxy_parser<Subject, without_directive<Subject, IDs...>>
+{
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
+    [[nodiscard]] constexpr bool
+    parse(It& first, Se const& last, Context const& ctx, Attr& attr) const
+        noexcept(
+            x4::is_nothrow_parsable_v<
+                Subject, It, Se,
+                std::remove_cvref_t<decltype(x4::remove_all_contexts<IDs...>(ctx))>,
+                Attr
+            >
+        )
+    {
+        return this->subject.parse(first, last, x4::remove_all_contexts<IDs...>(ctx), attr);
+    }
+
+    [[nodiscard]] constexpr std::string get_x4_info() const
+    {
+        return std::format("without<...>[{}]", get_info<Subject>{}(this->subject));
+    }
+};
+
+namespace detail {
+
+template<class... IDs>
+struct without_gen
+{
+    template<class Subject>
+    [[nodiscard]] constexpr without_directive<std::remove_cvref_t<Subject>, IDs...>
+    operator[](Subject&& subject) const // TODO: MSVC 2022 does not properly handle static operator[]
+        noexcept(std::is_nothrow_constructible_v<without_directive<std::remove_cvref_t<Subject>, IDs...>, Subject>)
+    {
+        return without_directive<std::remove_cvref_t<Subject>, IDs...>{
+            std::forward<Subject>(subject)
+        };
+    }
+};
+
+} // detail
+
+namespace parsers::directive {
+
+template<class... IDs>
+[[maybe_unused]] inline constexpr detail::without_gen<IDs...> without{};
+
+} // parsers::directive
+
+using parsers::directive::without;
+
+} // iris::x4
+
+#endif

--- a/test/x4/CMakeLists.txt
+++ b/test/x4/CMakeLists.txt
@@ -90,6 +90,7 @@ x4_define_tests(
     unused
     with
     with_local
+    without
     x3_rule_problem
     alloy_wrong_substitute_test_case
 )

--- a/test/x4/without.cpp
+++ b/test/x4/without.cpp
@@ -1,0 +1,95 @@
+/*=============================================================================
+    Copyright (c) 2026 The Iris Project Contributors
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include "iris_x4_test.hpp"
+
+#include <iris/x4/auxiliary/eps.hpp>
+#include <iris/x4/directive/without.hpp>
+#include <iris/x4/directive/with.hpp>
+#include <iris/x4/core/parser.hpp>
+
+#include <concepts>
+#include <iterator>
+
+template<class ExpectedContext>
+struct context_checker : x4::parser<context_checker<ExpectedContext>>
+{
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, x4::X4Attribute Attr>
+    [[nodiscard]] static constexpr bool parse(It&, Se const&, Context const&, Attr const&)
+    {
+        STATIC_CHECK(std::same_as<Context, ExpectedContext>);
+        return true;
+    }
+};
+
+static_assert(x4::X4ExplicitParser<context_checker<unused_type>, char const*, char const*>);
+
+struct OK {};
+struct Bad0 {};
+struct NonExistent {};
+
+TEST_CASE("without")
+{
+    using x4::without;
+    using x4::with;
+    using x4::context;
+
+    constexpr int dummy = 0;
+    char const* first = nullptr, *const last = nullptr;
+
+    {
+        (void)x4::with<OK>(dummy)[
+            x4::without<OK>[
+                context_checker<unused_type>{}
+            ]
+        ].parse(first, last, unused, unused);
+    }
+    {
+        (void)x4::with<OK>(dummy)[
+            x4::without<NonExistent>[
+                context_checker<context<OK, int const>>{}
+            ]
+        ].parse(first, last, unused, unused);
+    }
+
+    {
+        (void)x4::with<OK>(dummy)[
+            x4::with<Bad0>(dummy)[
+                x4::without<Bad0>[
+                    context_checker<context<OK, int const>>{}
+                ]
+            ]
+        ].parse(first, last, unused, unused);
+    }
+    {
+        (void)x4::with<OK>(dummy)[
+            x4::with<Bad0>(dummy)[
+                x4::without<OK>[
+                    context_checker<context<Bad0, int const>>{}
+                ]
+            ]
+        ].parse(first, last, unused, unused);
+    }
+    {
+        (void)x4::with<OK>(dummy)[
+            x4::with<Bad0>(dummy)[
+                x4::without<NonExistent>[
+                    context_checker<context<Bad0, int const, context<OK, int const> const&>>{}
+                ]
+            ]
+        ].parse(first, last, unused, unused);
+    }
+    {
+        (void)x4::with<OK>(dummy)[
+            x4::with<Bad0>(dummy)[
+                x4::without<OK, Bad0>[
+                    context_checker<unused_type>{}
+                ]
+            ]
+        ].parse(first, last, unused, unused);
+    }
+}


### PR DESCRIPTION
This PR implements the `without<IDs...>[p]` directive. It is the counterpart to `with<ID>(ref)[p]` and `with_local<T, ID>[p]`.

`without` strips out any contexts that match the IDs specified in the argument.

It is extremely useful for stripping unnecessary contexts from a parser type that is intended to be instantiated in a distinct translation unit. Without `without`, users must specify all the extraneous contexts specified by the full parser definition because `IRIS_X4_INSTANTIATE` requires the concrete context type. With `without`, users can shave off all the irrelevant contexts to minify the variations of the instantiated parser type.

Such operation is crucial for real-world grammars and it can often reduce the compile times proportionally.