### PR TITLE
Remove existing tuple_impl.hpp before rename

### DIFF
--- a/scripts/generate_tuple_members.bat
+++ b/scripts/generate_tuple_members.bat
@@ -7,6 +7,7 @@ cl /TP /std:c++23preview /Iinclude /Imodules\boost_preprocessor\include /Imodule
 pushd include\iris\alloy\detail\preprocessed
 type tuple_impl.hpp.pre.in temp.hpp tuple_impl.hpp.post.in > temp2.hpp
 clang-format -i temp2.hpp
+del /q tuple_impl.hpp
 rename temp2.hpp tuple_impl.hpp
 del temp.hpp
 popd


### PR DESCRIPTION
Windows command prompt's `rename` command cannot overwrite existing file.

This error happens only in local build (not on CI) because CI always starts from the clean `git clone`.