### PR TITLE
Fix `unused_container` propagation

### DIFF
--- a/include/iris/x4/directive/raw.hpp
+++ b/include/iris/x4/directive/raw.hpp
@@ -37,7 +37,7 @@ struct raw_directive : unary_parser<Subject, raw_directive<Subject>>
 
     static constexpr bool handles_container = true;
 
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4NonUnusedAttribute Attr>
     [[nodiscard]] constexpr bool
     parse(It& first, Se const& last, Context const& ctx, Attr& attr) const
         // never noexcept; construction of `std::ranges::subrange` is never noexcept
@@ -53,9 +53,9 @@ struct raw_directive : unary_parser<Subject, raw_directive<Subject>>
         return true;
     }
 
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context>
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4UnusedAttribute UnusedAttr>
     [[nodiscard]] constexpr bool
-    parse(It& first, Se const& last, Context const& ctx, unused_type) const
+    parse(It& first, Se const& last, Context const& ctx, UnusedAttr const&) const
         noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, unused_type>)
     {
         return this->subject.parse(first, last, ctx, unused);

--- a/include/iris/x4/operator/alternative.hpp
+++ b/include/iris/x4/operator/alternative.hpp
@@ -35,9 +35,9 @@ struct alternative : binary_parser<Left, Right, alternative<Left, Right>>
 
     using binary_parser<Left, Right, alternative>::binary_parser;
 
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context>
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4UnusedAttribute UnusedAttr>
     [[nodiscard]] constexpr bool
-    parse(It& first, Se const& last, Context const& ctx, unused_type) const
+    parse(It& first, Se const& last, Context const& ctx, UnusedAttr const&) const
         noexcept(
             is_nothrow_parsable_v<Left, It, Se, Context, unused_type> &&
             is_nothrow_parsable_v<Right, It, Se, Context, unused_type>
@@ -58,7 +58,7 @@ struct alternative : binary_parser<Left, Right, alternative<Left, Right>>
     //
     // You also should add test to `attribute.cpp`.
 
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, class Attr>
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4NonUnusedAttribute Attr>
         requires (!traits::X4Container<Attr>)
     [[nodiscard]] constexpr bool
     parse(It& first, Se const& last, Context const& ctx, Attr& attr) const
@@ -69,9 +69,6 @@ struct alternative : binary_parser<Left, Right, alternative<Left, Right>>
             noexcept(x4::move_to(std::declval<Attr>(), attr))
         )
     {
-        static_assert(!std::same_as<std::remove_const_t<Attr>, unused_type>);
-        static_assert(!std::same_as<std::remove_const_t<Attr>, unused_container_type>);
-
         static_assert(
             std::default_initializable<Attr>,
             "Attribute needs to be default-initializable to support rollback on failed parse attempt."

--- a/include/iris/x4/operator/sequence.hpp
+++ b/include/iris/x4/operator/sequence.hpp
@@ -38,9 +38,9 @@ struct sequence : binary_parser<Left, Right, sequence<Left, Right>>
 
     using binary_parser<Left, Right, sequence>::binary_parser;
 
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context>
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4UnusedAttribute UnusedAttr>
     [[nodiscard]] constexpr bool
-    parse(It& first, Se const& last, Context const& ctx, unused_type) const
+    parse(It& first, Se const& last, Context const& ctx, UnusedAttr const&) const
         noexcept(
             std::is_nothrow_copy_assignable_v<It> &&
             is_nothrow_parsable_v<Left, It, Se, Context, unused_type> &&
@@ -66,8 +66,7 @@ struct sequence : binary_parser<Left, Right, sequence<Left, Right>>
         return false;
     }
 
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, class Attr>
-        requires (!std::same_as<std::remove_const_t<Attr>, unused_type>)
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4NonUnusedAttribute Attr>
     [[nodiscard]] constexpr bool
     parse(It& first, Se const& last, Context const& ctx, Attr& attr) const
         noexcept(noexcept(detail::parse_sequence(*this, first, last, ctx, attr)))


### PR DESCRIPTION
Compound parsers should accept BOTH `unused_type` and `unused_container_type`.

Note that their types are accepted as-is but the values are unconditionally converted to `unused_type`. This is currently the correct solution because the parsers which need `unused_container_type` actually converts `unused_type` to `unused_container_type` in their parse function. If we instead *keep* the `unused_container` instance, some underlying parsers might fail to select the correct overload which relies on `unused_type` (instead of `unused_container_type`).