### PR TITLE
Split expectation headers

### DIFF
--- a/include/iris/x4/core/char_traits.hpp
+++ b/include/iris/x4/core/char_traits.hpp
@@ -8,6 +8,9 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ================================================_==============================*/
 
+// This header is intended for inclusion by user-facing, non-parser headers.
+// Do not add includes specific to X4's parser implementation here.
+
 #include <iris/config.hpp>
 
 #include <concepts>

--- a/include/iris/x4/core/expectation.hpp
+++ b/include/iris/x4/core/expectation.hpp
@@ -12,15 +12,13 @@
 
 #include <iris/config.hpp>
 
+#include <iris/x4/core/expectation_failure.hpp> // export
 #include <iris/x4/core/parser.hpp> // for `x4::what`
 #include <iris/x4/core/context.hpp>
 
 #include <iterator>
-#include <string>
 #include <type_traits>
 #include <utility>
-
-#include <cassert>
 
 namespace iris::x4 {
 
@@ -32,76 +30,6 @@ struct expectation_failure
 };
 
 } // contexts
-
-using expectation_failure_tag [[deprecated("Use `x4::contexts::expectation_failure`")]] = contexts::expectation_failure;
-
-template<std::forward_iterator It>
-struct expectation_failure
-{
-    constexpr expectation_failure() = default;
-
-    template<class WhichT>
-        requires std::is_constructible_v<std::string, WhichT>
-    constexpr expectation_failure(It where, WhichT&& which)
-        noexcept(std::is_nothrow_copy_constructible_v<It> && std::is_nothrow_constructible_v<std::string, WhichT>)
-        : where_(where)
-        , which_(std::forward<WhichT>(which))
-    {
-        if (which_.empty()) {
-            which_ = "(unknown location)";
-        }
-    }
-
-    [[nodiscard]]
-    constexpr It const& where() const noexcept
-    {
-        assert(this->has_value());
-        return where_;
-    }
-
-    [[nodiscard]]
-    constexpr std::string const& which() const noexcept
-    {
-        assert(this->has_value());
-        return which_;
-    }
-
-    constexpr void clear() noexcept
-    {
-        which_.clear();
-    }
-
-    template<class WhichT>
-        requires std::is_constructible_v<std::string, WhichT>
-    constexpr void emplace(It where, WhichT&& which)
-        noexcept(std::is_nothrow_move_assignable_v<It> && std::is_nothrow_assignable_v<std::string&, WhichT>)
-    {
-        where_ = std::move(where);
-        which_ = std::forward<WhichT>(which);
-    }
-
-    [[nodiscard]] constexpr explicit operator bool() const noexcept { return !which_.empty(); }
-    [[nodiscard]] constexpr bool has_value() const noexcept { return !which_.empty(); }
-
-    constexpr void swap(expectation_failure& other)
-        noexcept(std::is_nothrow_swappable_v<It> && std::is_nothrow_swappable_v<std::string>)
-    {
-        using std::swap;
-        swap(where_, other.where_);
-        swap(which_, other.which_);
-    }
-
-private:
-    It where_{};
-    std::string which_;
-};
-
-template<std::forward_iterator It>
-constexpr void swap(expectation_failure<It>& a, expectation_failure<It>& b)
-    noexcept(std::is_nothrow_swappable_v<It> && std::is_nothrow_swappable_v<std::string>)
-{
-    a.swap(b);
-}
 
 template<class Context>
 using expectation_failure_t = get_context_plain_t<contexts::expectation_failure, Context>;

--- a/include/iris/x4/core/expectation_failure.hpp
+++ b/include/iris/x4/core/expectation_failure.hpp
@@ -1,0 +1,97 @@
+#ifndef IRIS_ZZ_X4_CORE_EXPECTATION_FAILURE_HPP
+#define IRIS_ZZ_X4_CORE_EXPECTATION_FAILURE_HPP
+
+/*=============================================================================
+    Copyright (c) 2017 wanghan02
+    Copyright (c) 2024-2025 Nana Sakisaka
+    Copyright (c) 2026 The Iris Project Contributors
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+// This header is intended for inclusion by user-facing, non-parser headers.
+// Do not add includes specific to X4's parser implementation here.
+
+#include <iris/config.hpp>
+
+#include <iterator>
+#include <utility>
+#include <type_traits>
+#include <string>
+
+#include <cassert>
+
+namespace iris::x4 {
+
+template<std::forward_iterator It>
+struct expectation_failure
+{
+    constexpr expectation_failure() = default;
+
+    template<class WhichT>
+        requires std::is_constructible_v<std::string, WhichT>
+    constexpr expectation_failure(It where, WhichT&& which)
+        noexcept(std::is_nothrow_copy_constructible_v<It> && std::is_nothrow_constructible_v<std::string, WhichT>)
+        : where_(where)
+        , which_(std::forward<WhichT>(which))
+    {
+        if (which_.empty()) {
+            which_ = "(unknown location)";
+        }
+    }
+
+    [[nodiscard]]
+    constexpr It const& where() const noexcept
+    {
+        assert(this->has_value());
+        return where_;
+    }
+
+    [[nodiscard]]
+    constexpr std::string const& which() const noexcept
+    {
+        assert(this->has_value());
+        return which_;
+    }
+
+    constexpr void clear() noexcept
+    {
+        which_.clear();
+    }
+
+    template<class WhichT>
+        requires std::is_constructible_v<std::string, WhichT>
+    constexpr void emplace(It where, WhichT&& which)
+        noexcept(std::is_nothrow_move_assignable_v<It> && std::is_nothrow_assignable_v<std::string&, WhichT>)
+    {
+        where_ = std::move(where);
+        which_ = std::forward<WhichT>(which);
+    }
+
+    [[nodiscard]] constexpr explicit operator bool() const noexcept { return !which_.empty(); }
+    [[nodiscard]] constexpr bool has_value() const noexcept { return !which_.empty(); }
+
+    constexpr void swap(expectation_failure& other)
+        noexcept(std::is_nothrow_swappable_v<It> && std::is_nothrow_swappable_v<std::string>)
+    {
+        using std::swap;
+        swap(where_, other.where_);
+        swap(which_, other.which_);
+    }
+
+private:
+    It where_{};
+    std::string which_;
+};
+
+template<std::forward_iterator It>
+constexpr void swap(expectation_failure<It>& a, expectation_failure<It>& b)
+    noexcept(std::is_nothrow_swappable_v<It> && std::is_nothrow_swappable_v<std::string>)
+{
+    a.swap(b);
+}
+
+} // iris::x4
+
+#endif

--- a/include/iris/x4/parse_result.hpp
+++ b/include/iris/x4/parse_result.hpp
@@ -9,8 +9,11 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
+// This header is intended for inclusion by user-facing, non-parser headers.
+// Do not add includes specific to X4's parser implementation here.
+
 #include <iris/config.hpp>
-#include <iris/x4/core/expectation.hpp>
+#include <iris/x4/core/expectation_failure.hpp>
 #include <iris/x4/core/char_traits.hpp>
 
 #include <iterator>


### PR DESCRIPTION
Split `<iris/x4/core/expectation.hpp>` and `<iris/x4/core/expectation_failure.hpp>`