### PR TITLE
Add string_view support for `fixed_value` constructors

### DIFF
--- a/include/iris/x4/attribute/value.hpp
+++ b/include/iris/x4/attribute/value.hpp
@@ -146,6 +146,20 @@ struct fixed_value_gen
         return fixed_value_parser<std::remove_cvref_t<T>>{std::forward<T>(value)};
     }
 
+    [[nodiscard]] static constexpr fixed_value_parser<std::string, std::string_view>
+    operator()(std::string_view value)
+        noexcept(std::is_nothrow_constructible_v<fixed_value_parser<std::string, std::string_view>, std::string_view>)
+    {
+        return fixed_value_parser<std::string, std::string_view>{value};
+    }
+
+    [[nodiscard]] static constexpr fixed_value_parser<std::u32string, std::u32string_view>
+    operator()(std::u32string_view value)
+        noexcept(std::is_nothrow_constructible_v<fixed_value_parser<std::u32string, std::u32string_view>, std::u32string_view>)
+    {
+        return fixed_value_parser<std::u32string, std::u32string_view>{value};
+    }
+
     template<CharArray CharArrayT>
     [[nodiscard]] static constexpr string_array_attr_parser_t<CharArrayT>
     operator()(CharArrayT&& char_array)

--- a/test/x4/value.cpp
+++ b/test/x4/value.cpp
@@ -71,7 +71,7 @@ TEST_CASE("attr")
     }
     {
         [[maybe_unused]] constexpr auto attr_p = fixed_value("foo"sv);
-        STATIC_CHECK(std::same_as<std::remove_const_t<decltype(attr_p)>, x4::fixed_value_parser<std::basic_string_view<char>>>);
+        STATIC_CHECK(std::same_as<std::remove_const_t<decltype(attr_p)>, x4::fixed_value_parser<std::basic_string<char>, std::basic_string_view<char>>>);
     }
 
     {
@@ -84,7 +84,7 @@ TEST_CASE("attr")
     }
     {
         [[maybe_unused]] constexpr auto attr_p = fixed_value(U"foo"sv);
-        STATIC_CHECK(std::same_as<std::remove_const_t<decltype(attr_p)>, x4::fixed_value_parser<std::basic_string_view<char32_t>>>);
+        STATIC_CHECK(std::same_as<std::remove_const_t<decltype(attr_p)>, x4::fixed_value_parser<std::basic_string<char32_t>, std::basic_string_view<char32_t>>>);
     }
 
     IRIS_X4_ASSERT_CONSTEXPR_CTORS(fixed_value(1));


### PR DESCRIPTION
This improves `constexpr` support.